### PR TITLE
feat(ops): implement manage sync-csv (#8)

### DIFF
--- a/src/zotero_cli/cli/commands/manage_cmd.py
+++ b/src/zotero_cli/cli/commands/manage_cmd.py
@@ -1,0 +1,175 @@
+import argparse
+import sys
+from rich.console import Console
+from rich.table import Table
+
+from zotero_cli.cli.base import BaseCommand, CommandRegistry
+from zotero_cli.core.services.tag_service import TagService
+from zotero_cli.core.services.attachment_service import AttachmentService
+from zotero_cli.core.services.duplicate_service import DuplicateFinder
+from zotero_cli.core.services.collection_service import CollectionService
+from zotero_cli.core.services.migration_service import MigrationService
+from zotero_cli.core.services.sync_service import SyncService
+
+console = Console()
+
+@CommandRegistry.register
+class ManageCommand(BaseCommand):
+    name = "manage"
+    help = "Library Maintenance (tags, pdfs, duplicates, etc.)"
+
+    def register_args(self, parser: argparse.ArgumentParser):
+        sub = parser.add_subparsers(dest="manage_type", required=True)
+        
+        # Tags
+        tag_p = sub.add_parser("tags", help="Tag operations")
+        tag_p.add_argument("action", choices=["list", "rename", "delete", "add", "remove"])
+        tag_p.add_argument("--tag")
+        tag_p.add_argument("--old")
+        tag_p.add_argument("--new")
+        tag_p.add_argument("--item")
+        tag_p.add_argument("--tags")
+        
+        # PDFs
+        pdf_p = sub.add_parser("pdfs", help="PDF operations")
+        pdf_p.add_argument("action", choices=["fetch", "strip"])
+        pdf_p.add_argument("--collection", required=True)
+        pdf_p.add_argument("--verbose", action="store_true")
+        
+        # Duplicates
+        dup_p = sub.add_parser("duplicates", help="Find duplicates")
+        dup_p.add_argument("--collections", required=True)
+        
+        # Move
+        move_p = sub.add_parser("move", help="Move item")
+        move_p.add_argument("--item-id", required=True)
+        move_p.add_argument("--source", required=True)
+        move_p.add_argument("--target", required=True)
+        
+        # Clean
+        clean_p = sub.add_parser("clean", help="Empty a collection")
+        clean_p.add_argument("--collection", required=True)
+        clean_p.add_argument("--parent")
+        clean_p.add_argument("--verbose", action="store_true")
+        
+        # Migrate
+        mig_p = sub.add_parser("migrate", help="Migrate audit notes")
+        mig_p.add_argument("--collection", required=True)
+        mig_p.add_argument("--dry-run", action="store_true")
+
+        # Sync-CSV
+        sync_p = sub.add_parser("sync-csv", help="Recover local CSV from Zotero notes")
+        sync_p.add_argument("--collection", required=True)
+        sync_p.add_argument("--output", required=True)
+
+    def execute(self, args: argparse.Namespace):
+        from zotero_cli.infra.factory import GatewayFactory
+        gateway = GatewayFactory.get_zotero_gateway(force_user=getattr(args, 'user', False))
+        
+        if args.manage_type == "tags":
+            self._handle_tags(gateway, args)
+        elif args.manage_type == "pdfs":
+            self._handle_pdfs(gateway, args)
+        elif args.manage_type == "duplicates":
+            self._handle_duplicates(gateway, args)
+        elif args.manage_type == "move":
+            self._handle_move(gateway, args)
+        elif args.manage_type == "clean":
+            self._handle_clean(gateway, args)
+        elif args.manage_type == "migrate":
+            self._handle_migrate(gateway, args)
+        elif args.manage_type == "sync-csv":
+            self._handle_sync_csv(gateway, args)
+
+    def _handle_tags(self, gateway, args):
+        service = TagService(gateway)
+        if args.action == "list":
+            tags = service.list_tags()
+            for t in sorted(tags): print(t)
+        elif args.action == "rename":
+            if not args.old or not args.new:
+                print("Error: --old and --new required.")
+                return
+            service.rename_tag(args.old, args.new)
+        elif args.action == "delete":
+            if not args.tag:
+                print("Error: --tag required.")
+                return
+            service.delete_tag(args.tag)
+        elif args.action == "add":
+            if not args.item or not args.tags:
+                print("Error: --item and --tags required.")
+                return
+            tags = [t.strip() for t in args.tags.split(',')]
+            service.add_tags_to_item(args.item, tags)
+        elif args.action == "remove":
+            if not args.item or not args.tags:
+                print("Error: --item and --tags required.")
+                return
+            tags = [t.strip() for t in args.tags.split(',')]
+            service.remove_tags_from_item(args.item, tags)
+
+    def _handle_pdfs(self, gateway, args):
+        from zotero_cli.infra.factory import GatewayFactory
+        service = GatewayFactory.get_attachment_service(force_user=getattr(args, 'user', False))
+        if args.action == "fetch":
+            from zotero_cli.infra.factory import GatewayFactory
+            importer = GatewayFactory.get_paper_importer(force_user=getattr(args, 'user', False))
+            count = importer.fetch_missing_pdfs(args.collection, args.verbose)
+            print(f"Fetched {count} PDFs.")
+        elif args.action == "strip":
+             from zotero_cli.infra.factory import GatewayFactory
+             importer = GatewayFactory.get_paper_importer(force_user=getattr(args, 'user', False))
+             count = importer.remove_attachments_from_folder(args.collection, args.verbose)
+             print(f"Removed {count} attachments.")
+
+    def _handle_duplicates(self, gateway, args):
+        service = DuplicateFinder(gateway)
+        col_ids = [c.strip() for c in args.collections.split(',')]
+        dupes = service.find_duplicates(col_ids)
+        if not dupes:
+            print("No duplicates found.")
+            return
+        table = Table(title="Duplicate Items")
+        table.add_column("Title")
+        table.add_column("DOI")
+        table.add_column("Keys")
+        for d in dupes:
+            table.add_row(d['title'], d['doi'] or 'N/A', ", ".join(d['keys']))
+        console.print(table)
+
+    def _handle_move(self, gateway, args):
+        service = CollectionService(gateway)
+        if service.move_item(args.item_id, args.source, args.target):
+            print(f"Moved item {args.item_id} from {args.source} to {args.target}.")
+        else:
+            print("Failed to move item.")
+
+    def _handle_clean(self, gateway, args):
+        service = CollectionService(gateway)
+        count = service.empty_collection(args.collection, args.parent, args.verbose)
+        print(f"Deleted {count} items.")
+
+    def _handle_migrate(self, gateway, args):
+        service = MigrationService(gateway)
+        results = service.migrate_collection_notes(args.collection, args.dry_run)
+        print(f"Migration results for {args.collection}:")
+        print(f"  Processed: {results['processed']}")
+        print(f"  Migrated:  {results['migrated']}")
+        print(f"  Failed:    {results['failed']}")
+
+    def _handle_sync_csv(self, gateway, args):
+        service = SyncService(gateway)
+        
+        def cli_progress(current, total, msg):
+            percent = (current / total * 100) if total > 0 else 0
+            sys.stdout.write(f"\r[{percent:5.1f}%] {msg:<60}")
+            sys.stdout.flush()
+
+        print(f"Syncing local CSV from '{args.collection}' notes...")
+        success = service.recover_state_from_notes(args.collection, args.output, cli_progress)
+        print("")
+        if success:
+            print(f"Successfully recovered state to '{args.output}'.")
+        else:
+            sys.exit(1)

--- a/src/zotero_cli/core/services/sync_service.py
+++ b/src/zotero_cli/core/services/sync_service.py
@@ -1,0 +1,118 @@
+import json
+import csv
+import sys
+from typing import List, Dict, Optional, Callable
+from zotero_cli.core.interfaces import ZoteroGateway
+from zotero_cli.core.zotero_item import ZoteroItem
+
+# Progress Callback Type: current, total, message
+ProgressCallback = Callable[[int, int, str], None]
+
+class SyncService:
+    """
+    Service responsible for synchronizing local state (CSV) from remote truth (Zotero Notes).
+    """
+    
+    def __init__(self, gateway: ZoteroGateway):
+        self.gateway = gateway
+
+    def recover_state_from_notes(
+        self, 
+        collection_name: str, 
+        output_csv_path: str,
+        callback: Optional[ProgressCallback] = None
+    ) -> bool:
+        """
+        Scans a collection, finds screening notes, and rebuilds the CSV file.
+        
+        Args:
+            collection_name: The Zotero collection to scan.
+            output_csv_path: Path to write the recovered CSV.
+            callback: Optional progress reporter.
+            
+        Returns:
+            bool: True if successful.
+        """
+        # 1. Resolve ID
+        if callback: callback(0, 0, "Resolving collection ID...")
+        collection_id = self.gateway.get_collection_id_by_name(collection_name)
+        if not collection_id:
+            print(f"Error: Collection '{collection_name}' not found.", file=sys.stderr)
+            return False
+
+        # 2. Fetch Items
+        if callback: callback(0, 0, f"Fetching items from '{collection_name}'...")
+        items = list(self.gateway.get_items_in_collection(collection_id))
+        total = len(items)
+        
+        recovered_rows: List[Dict[str, str]] = []
+        
+        # 3. Process Items
+        for idx, item in enumerate(items):
+            if callback: callback(idx + 1, total, f"Scanning: {item.title[:30]}...")
+            
+            # Find the screening note
+            screening_data = self._extract_screening_data(item)
+            
+            if screening_data:
+                # Map to CSV schema
+                row = {
+                    "key": item.key,
+                    "title": item.title,
+                    "decision": screening_data.get("decision", "unknown"),
+                    "reason": screening_data.get("reason", ""),
+                    "criteria": ",".join(screening_data.get("criteria", [])),
+                    "timestamp": screening_data.get("timestamp", "")
+                }
+                recovered_rows.append(row)
+
+        # 4. Write CSV
+        if callback: callback(total, total, f"Writing {len(recovered_rows)} records to {output_csv_path}...")
+        
+        try:
+            with open(output_csv_path, 'w', newline='', encoding='utf-8') as csvfile:
+                fieldnames = ['key', 'title', 'decision', 'reason', 'criteria', 'timestamp']
+                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                
+                writer.writeheader()
+                for row in recovered_rows:
+                    writer.writerow(row)
+            return True
+        except IOError as e:
+            print(f"Error writing CSV: {e}", file=sys.stderr)
+            return False
+
+    def _extract_screening_data(self, item: ZoteroItem) -> Optional[Dict]:
+        """
+        Helper to find and parse the JSON note attached to an item.
+        """
+        # We need to fetch children for this specific item
+        # Ideally, get_items_in_collection should optionally pre-fetch children, 
+        # but for now we do a N+1 query (or O(1) if cached).
+        # Optimization: The Gateway implementation might be lazy.
+        
+        children = self.gateway.get_item_children(item.key)
+        
+        for child in children:
+            # Check if it's a note
+            if child.get('data', {}).get('itemType') == 'note':
+                note_content = child['data'].get('note', '')
+                
+                # Check for our signature
+                if "screening_decision" in note_content:
+                    try:
+                        # Extract the JSON block
+                        # Usually wrapped in <pre> or ```json
+                        # Simple robust parser: look for { ... }
+                        start = note_content.find('{')
+                        end = note_content.rfind('}') + 1
+                        if start != -1 and end != -1:
+                            json_str = note_content[start:end]
+                            # Clean up HTML entities if necessary? 
+                            # Usually Zotero API returns clean text or HTML.
+                            # Assuming HTML stripping might be needed if it's rich text.
+                            # For this MVP, we assume the JSON is parseable.
+                            return json.loads(json_str)
+                    except json.JSONDecodeError:
+                        continue
+        return None

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import MagicMock
+from zotero_cli.core.services.sync_service import SyncService
+from zotero_cli.core.zotero_item import ZoteroItem
+
+class TestSyncService(unittest.TestCase):
+    def setUp(self):
+        self.gateway = MagicMock()
+        self.service = SyncService(self.gateway)
+
+    def test_recover_state_from_notes_success(self):
+        # Mock Collection ID
+        self.gateway.get_collection_id_by_name.return_value = "ColID"
+        
+        # Mock Items
+        item1 = ZoteroItem(key="K1", title="Paper A", version=1, item_type="journalArticle")
+        item2 = ZoteroItem(key="K2", title="Paper B", version=1, item_type="journalArticle")
+        self.gateway.get_items_in_collection.return_value = [item1, item2]
+        
+        # Mock Children (Notes)
+        # Item 1 has a valid screening note
+        note_content = 'Pre-text <pre>{"decision": "approve", "reason": "Relevant", "criteria": ["IC1"], "timestamp": "2024-01-01"}</pre>'
+        self.gateway.get_item_children.side_effect = [
+            [{'data': {'itemType': 'note', 'note': f"screening_decision: {note_content}"}}], # Item 1
+            [] # Item 2 (No notes)
+        ]
+        
+        from unittest.mock import patch, mock_open
+        with patch("builtins.open", mock_open()) as mock_file:
+            success = self.service.recover_state_from_notes("Test Col", "dummy.csv")
+            
+            self.assertTrue(success)
+            # Verify file write
+            mock_file.assert_called_with("dummy.csv", 'w', newline='', encoding='utf-8')
+            handle = mock_file()
+            # Check header
+            handle.write.assert_any_call("key,title,decision,reason,criteria,timestamp\r\n")
+            # Check row
+            handle.write.assert_any_call("K1,Paper A,approve,Relevant,IC1,2024-01-01\r\n")
+
+    def test_extract_screening_data_valid(self):
+        item = ZoteroItem(key="K1", title="T", version=1, item_type="journalArticle")
+        json_str = '{"decision": "reject", "reason": "Old", "criteria": ["EC2"]}'
+        note = f'Some text screening_decision: ```json\n{json_str}\n```'
+        
+        self.gateway.get_item_children.return_value = [
+            {'data': {'itemType': 'note', 'note': note}}
+        ]
+        
+        data = self.service._extract_screening_data(item)
+        self.assertEqual(data['decision'], 'reject')
+        self.assertEqual(data['criteria'], ['EC2'])
+
+    def test_extract_screening_data_none(self):
+        item = ZoteroItem(key="K1", title="T", version=1, item_type="journalArticle")
+        self.gateway.get_item_children.return_value = [{'data': {'itemType': 'attachment'}}]
+        
+        data = self.service._extract_screening_data(item)
+        self.assertIsNone(data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### 🎯 Objective
Recover local CSV screening state from Zotero Child Notes (Source of Truth).

### 🛠 Implementation
*   **Service:** `SyncService` scans items and parses JSON blocks from notes.
*   **CLI:** Added `manage sync-csv --collection <name> --output <file.csv>`.
*   **Tests:** Added `tests/test_sync_service.py` (Mocked).

### ✅ Verification
1.  Run `zotero-cli manage sync-csv --collection "My Collection" --output recovered.csv`
2.  Verify CSV contains `decision` and `reason` fields.